### PR TITLE
Add initial version of migration trigger workflow

### DIFF
--- a/.github/workflows/migrate.yaml
+++ b/.github/workflows/migrate.yaml
@@ -1,0 +1,58 @@
+name: Trigger Database Migrations
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  migrate-cdb:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true  # Only trigger on merged PRs
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+
+      - name: Fetch main branch
+        run: git fetch origin main
+
+      - name: Set relative path to schema directory
+        run: |
+          echo "SCHEMA_DIR=python/lsst/sdm_schemas/schemas" >> $GITHUB_ENV
+
+      - name: Check for changed cdb schemas  # TODO: Use 'felis diff -c alembic' when available (DM-46130)
+        run: |
+          CHANGED_FILES=$(git diff --name-only origin/main..HEAD -- ${{ env.SCHEMA_DIR }})
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No schema files changed"
+            exit 0
+          fi
+          CHANGED_FILES=$(echo $CHANGED_FILES | xargs basename | grep -E '^cdb_.*\.yaml$')
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No cdb schema files changed"
+            exit 0
+          fi
+          echo "Changed cdb schema files: $CHANGED_FILES"
+
+      - name: Print branch name and commit SHA
+        run: |
+          echo "Branch name: ${{ github.head_ref }}"
+          echo "Commit SHA: ${{ github.event.pull_request.merge_commit_sha }}"
+
+      - name: Trigger migration workflow in consdb repository
+        run: |
+          curl -X POST \
+          -H "Authorization: token ${{ secrets.REPO_DISPATCH_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/lsst-dm/consdb/dispatches \
+          -d '{
+              "event_type": "migration",
+              "client_payload": {
+                "branch_name": "${{ github.head_ref }}",
+                "commit_sha": "${{ github.event.pull_request.merge_commit_sha }}"
+              }
+          }'

--- a/.github/workflows/migrate.yaml
+++ b/.github/workflows/migrate.yaml
@@ -1,37 +1,29 @@
 name: Trigger Database Migrations
 
 on:
-  pull_request:
-    types: [closed]
+  push:
+    branches:
+      - main
 
 jobs:
   migrate-cdb:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true  # Only trigger on merged PRs
 
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
-
-      - name: Fetch main branch
-        run: git fetch origin main
-
-      - name: Set relative path to schema directory
-        run: |
-          echo "SCHEMA_DIR=python/lsst/sdm_schemas/schemas" >> $GITHUB_ENV
 
       - name: Check for changed cdb schemas  # TODO: Use 'felis diff -c alembic' when available (DM-46130)
         run: |
-          CHANGED_FILES=$(git diff --name-only origin/main..HEAD -- ${{ env.SCHEMA_DIR }})
+          CHANGED_FILES=$(git diff --name-only origin/main..HEAD -- python/lsst/sdm_schemas/schemas)
           if [ -z "$CHANGED_FILES" ]; then
             echo "No schema files changed"
             exit 0
           fi
-          CHANGED_FILES=$(echo $CHANGED_FILES | xargs basename | grep -E '^cdb_.*\.yaml$')
+          CHANGED_FILES=$(echo $CHANGED_FILES | grep -E '/cdb_.*\.yaml$')
           if [ -z "$CHANGED_FILES" ]; then
             echo "No cdb schema files changed"
             exit 0
@@ -44,15 +36,9 @@ jobs:
           echo "Commit SHA: ${{ github.event.pull_request.merge_commit_sha }}"
 
       - name: Trigger migration workflow in consdb repository
-        run: |
-          curl -X POST \
-          -H "Authorization: token ${{ secrets.REPO_DISPATCH_TOKEN }}" \
-          -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/lsst-dm/consdb/dispatches \
-          -d '{
-              "event_type": "migration",
-              "client_payload": {
-                "branch_name": "${{ github.head_ref }}",
-                "commit_sha": "${{ github.event.pull_request.merge_commit_sha }}"
-              }
-          }'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.REPO_DISPATCH_TOKEN }}
+          repository: JeremyMcCormick/consdb-dm-47507
+          event-type: migration
+          client-payload: '{"branch_name": "${{ github.head_ref }}", "commit_sha": "${{ github.event.pull_request.merge_commit_sha }}"}'


### PR DESCRIPTION
This workflow can be used to trigger migration workflows in other repositories.

Currently, it has a single job that triggers ConsDB migrations in the lsst-dm/consdb repo.